### PR TITLE
Add admin editing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'bootstrap', '~> 4.1.3'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'pundit'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
     puma (3.12.0)
+    pundit (2.0.0)
+      activesupport (>= 3.0.0)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -263,6 +265,7 @@ DEPENDENCIES
   poltergeist
   pry
   puma (~> 3.11)
+  pundit
   rails (~> 5.2.0)
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,0 +1,22 @@
+class Admin::AdminController < ApplicationController
+  before_action :authenticate_user!
+  before_action :verify_admin
+
+  private 
+
+  def verify_admin
+    unless current_user.admin?
+      flash[:error] = "You are not authorized to perform this action."
+      redirect_to root_path unless current_user.admin?
+    end
+  end
+
+  def policy_scope(scope)
+    super([:admin, scope])
+  end
+
+  def authorize(record, query = nil)
+    super([:admin, record], query)
+  end
+
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,36 @@
+class Admin::UsersController < Admin::AdminController
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
+
+  def index 
+    @users = User.all
+  end
+
+  def edit 
+  end
+
+  def update 
+    if @user.update(user_params)
+      redirect_to admin_users_path
+    else  
+      render :edit
+    end
+  end
+
+  def destroy 
+    @user.destroy
+    redirect_to admin_users_path, success: "User successfully deleted"
+  end
+
+  private 
+  
+  def set_user 
+    @user = User.find_by(id: params[:id])
+    authorize @user
+    redirect_to admin_users_path unless @user
+  end
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, role_ids: [])
+  end
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
     end
 
     def user_not_authorized
-      flash[:alert] = "You are not authorized to perform this action."
+      flash[:error] = "You are not authorized to perform this action."
       redirect_to(request.referrer || root_path)
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include Pundit
   protect_from_forgery
 
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
   private
     def authorize_name
       redirect_to edit_user_path(current_user) if user_signed_in? && current_user.first_name.nil?
@@ -9,5 +11,10 @@ class ApplicationController < ActionController::Base
     
     def authorize_user
       redirect_to root_path if !user_signed_in? || !current_user.admin? || !current_user.instructor?
+    end
+
+    def user_not_authorized
+      flash[:alert] = "You are not authorized to perform this action."
+      redirect_to(request.referrer || root_path)
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pundit
+  protect_from_forgery
 
   private
     def authorize_name

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -1,0 +1,28 @@
+class Admin::UserPolicy < ApplicationPolicy
+  attr_reader :user, :user_record
+
+  def initialize(user, user_record)
+    @user = user 
+    @user_record = user_record
+  end
+
+  def index?
+    user.admin?
+  end
+
+  def show?
+    index?
+  end
+
+  def edit?
+    user.admin? && !user_record.admin?
+  end
+
+  def update?
+    index?
+  end
+
+  def destroy?
+    user.admin? && user == user_record
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,49 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,26 @@
+<H2>Edit User</h2>
+<%= form_for [:admin, @user] do |f| %>
+
+  <div class="field form-group">
+    <%= f.label :first_name %><br />
+    <%= f.text_field :first_name, autofocus: true, autocomplete: "off", class: "form-control" %>
+  </div>
+
+  <div class="field form-group">
+    <%= f.label :last_name %>
+    <%= f.text_field :last_name, autocomplete: "off", class: "form-control" %>
+  </div>
+
+  <div class="field form-group">
+    <%= f.label :roles %>: 
+    <%= f.collection_check_boxes :role_ids, Role.all, :id, :name, class: "form-control" do |b| %>
+      <div>
+        <%= b.label(class:"label-checkbox") { b.check_box + " #{b.text}" } %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Edit Account", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,24 @@
+<h1>Users</h1>
+<br/>
+<table class="table table-striped">
+  <thead class="thead-dark">
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">First Name</th>
+      <th scope="col">Last Name</th>
+      <th scope="col">Roles</th>
+      <th scope="col">Links</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each.with_index(1) do |user, i| %>
+      <tr>
+        <th scope="row"><%= i %></th>
+        <td><%= user.first_name %></td>
+        <td><%= user.last_name %></td>
+        <td><%= user.roles.map{|u| u.name}.join(", ") %></td>
+        <td><%= link_to "Edit", edit_admin_user_path(user) %>, <%= link_to "Delete", admin_user_path(user), method: "delete" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -29,7 +29,7 @@
       </a>
       <div class="dropdown-menu" aria-labelledby="admin-dropdown">
         <%= link_to "View All Cohorts", admin_cohorts_path, class: "dropdown-item" %>
-        <%= link_to "Change User Role", "#", class: "dropdown-item" %>
+        <%= link_to "Users", admin_users_path, class: "dropdown-item" %>
       </div>
     </li>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get '/cohorts', to: 'cohorts#index', as: 'cohorts'
     get '/cohorts/:id', to: 'cohorts#show', as: 'cohort'
     get '/cohorts/:cohort_id/students/:id', to: 'students#show', as: 'cohort_student'
+    resources :users
   end
 
   resources :users do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -43,9 +43,13 @@ FactoryBot.define do
   end
 
   # # This will use the User class (Admin would have been guessed)
-  # factory :admin, class: User do
-  #   first_name "Admin"
-  #   last_name  "User"
-  #   admin      true
-  # end
+  factory :admin, class: User do
+    email "admin@admin.com"
+    password "admin"
+    first_name "Admin"
+    last_name  "User"
+    after(:create) do |user|
+      user.roles << create(:admin_role)
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,7 +45,7 @@ FactoryBot.define do
   # # This will use the User class (Admin would have been guessed)
   factory :admin, class: User do
     email "admin@admin.com"
-    password "admin"
+    password "adminpass"
     first_name "Admin"
     last_name  "User"
     after(:create) do |user|

--- a/spec/features/admin_users_spec.rb
+++ b/spec/features/admin_users_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.feature "Admin Users", type: :feature do
+  describe "Index Page" do 
+    it "does not allow non-admins to view" do 
+      instructor_login 
+      visit admin_users_path
+      expect(current_path).to eq('/')
+      expect(page).to have_content("You are not authorized to perform this action.")
+    end
+  end
+end

--- a/spec/features/admin_users_spec.rb
+++ b/spec/features/admin_users_spec.rb
@@ -8,5 +8,29 @@ RSpec.feature "Admin Users", type: :feature do
       expect(current_path).to eq('/')
       expect(page).to have_content("You are not authorized to perform this action.")
     end
+
+    it "allows admins to edit user roles" do 
+      admin_login
+      attrs = attributes_for(:instructor)
+      create(:instructor)
+      instructor_role = create(:instructor_role)
+      student_role = create(:student_role)
+      visit admin_users_path
+      expect(current_path).to eq(admin_users_path)
+      find('tr:nth-child(2)').click_link("Edit")
+      check "user_role_ids_#{instructor_role.id}"
+      check "user_role_ids_#{student_role.id}"
+      submit_form
+      instructor = User.find_by(email: attrs[:email])
+      expect(instructor.roles).to include(instructor_role)
+      expect(instructor.roles).to include(student_role)
+
+      find('tr:nth-child(2)').click_link("Edit")
+      uncheck "user_role_ids_#{student_role.id}"
+      submit_form
+      instructor = User.find_by(email: attrs[:email])
+      expect(instructor.roles).to include(instructor_role)
+      expect(instructor.roles).not_to include(student_role)
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
+Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
@@ -28,6 +29,8 @@ end
 
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.include FormHelpers, :type => :feature
+  config.include LoginHelper, :type => :feature
   config.include Warden::Test::Helpers
   config.include FactoryBot::Syntax::Methods
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -1,0 +1,5 @@
+module FormHelpers
+  def submit_form
+    find('input[name="commit"]').click
+  end
+end

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -10,7 +10,12 @@ module LoginHelper
   end
 
   def admin_login
-    
+    attrs = attributes_for(:admin)
+    create(:admin)
+    visit new_user_session_path
+    fill_in "user_email", with: attrs[:email]
+    fill_in "user_password", with: attrs[:password]
+    submit_form
   end
 
 end

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -1,0 +1,16 @@
+module LoginHelper
+
+  def instructor_login
+    attrs = attributes_for(:instructor)
+    create(:instructor)
+    visit new_user_session_path
+    fill_in "user_email", with: attrs[:email]
+    fill_in "user_password", with: attrs[:password]
+    submit_form
+  end
+
+  def admin_login
+    
+  end
+
+end


### PR DESCRIPTION
@Enoch2k2 this allows admin users to toggle roles for other users via the edit route at /admin/users/:id/edit. It doesn't allow users to delete other users accounts, but it would allow an admin to delete their own account. Let me know if you have any questions about the changes, the ones including Pundit especially.

Right now, the user_policy class is just specifying who is able to do what within the admin users controller. At the moment:
all admins can view the list
all admins can edit other users unless they're also admins
only an admin can delete their own account. (Admin users can't currently delete other users accounts)

Let me know if this makes sense or what you think would be better and I can update the PR.